### PR TITLE
fix typo in plugin name: "analisys" -> "analysis"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ allprojects {
 }
 
 opensearchplugin {
-  name = 'opensearch-analisys-ik'
+  name = 'opensearch-analysis-ik'
   description = 'IK Analysis for OpenSearch'
   classname = 'org.opensearch.plugin.analysis.ik.AnalysisIkPlugin'
   licenseFile = rootProject.file('LICENSE.txt')
@@ -92,16 +92,16 @@ throw new Exception('Missing property GITHUB_TOKEN')
 }
 
 // check if zip file is there
-if(file("build/distributions/opensearch-analisys-ik-${version}.zip").exists()){
+if(file("build/distributions/opensearch-analysis-ik-${version}.zip").exists()){
   // rename zip file
   def currentVersion = version.replace('-SNAPSHOT', '')
-  def filename = "build/distributions/opensearch-analisys-ik-${version}.zip"
-  Files.copy(file("build/distributions/opensearch-analisys-ik-${version}.zip").toPath(), file(filename).toPath())
+  def filename = "build/distributions/opensearch-analysis-ik-${version}.zip"
+  Files.copy(file("build/distributions/opensearch-analysis-ik-${version}.zip").toPath(), file(filename).toPath())
 
   // configuration
   githubRelease {
       owner 'aparo'
-      repo 'opensearch-analisys-ik'
+      repo 'opensearch-analysis-ik'
       token System.getProperty('GITHUB_TOKEN')
       tagName currentVersion
       releaseName currentVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'opensearch-analisys-ik'
+rootProject.name = 'opensearch-analysis-ik'


### PR DESCRIPTION
note that existing releases have this typo in the artifact name as well,
accordingly the links in `README.md` have been left unchanged.
(incidentally, this is how i noticed it: the artifact name looked
weird).

please note that that this PR is untested as the project cannot easily
be built locally due to the way the `build.gradle` is written with
release-checks as code in the middle of it (this should really be in a
task containing release checks). issue #2 has been raised for this.

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>