### PR TITLE
prepare release 2.0.1 for OpenSearch 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,17 @@ Analyzer: `ik_smart` , `ik_max_word` , Tokenizer: `ik_smart` , `ik_max_word`
 Install
 -------
 
-| OS    | Command |
-| ----- | ------- |
-| 1.1.0  | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.1.0/opensearch-analisys-ik-1.1.0.zip` |
-| 1.2.0  | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.2.0/opensearch-analisys-ik-1.2.0.zip` |
-| 1.2.2  | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.2.2/opensearch-analisys-ik-1.2.2.zip` |
-| 1.2.3  | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.2.3/opensearch-analisys-ik-1.2.3.zip` |
-| 1.3.0  | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.3.0/opensearch-analisys-ik-1.3.0.zip` |
-| 1.3.1  | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.3.1/opensearch-analisys-ik-1.3.1.zip` |
-| 1.3.2  | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.3.2/opensearch-analisys-ik-1.3.2.zip` |
-| 2.0.0  | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/2.0.0/opensearch-analisys-ik-2.0.0.zip` |
+| OS    | Command                                                                                                                                  |
+|-------|------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.0 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.1.0/opensearch-analisys-ik-1.1.0.zip` |
+| 1.2.0 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.2.0/opensearch-analisys-ik-1.2.0.zip` |
+| 1.2.2 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.2.2/opensearch-analisys-ik-1.2.2.zip` |
+| 1.2.3 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.2.3/opensearch-analisys-ik-1.2.3.zip` |
+| 1.3.0 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.3.0/opensearch-analisys-ik-1.3.0.zip` |
+| 1.3.1 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.3.1/opensearch-analisys-ik-1.3.1.zip` |
+| 1.3.2 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/1.3.2/opensearch-analisys-ik-1.3.2.zip` |
+| 2.0.0 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/2.0.0/opensearch-analisys-ik-2.0.0.zip` |
+| 2.0.1 | `bin/opensearch-plugin install https://github.com/aparo/opensearch-analysis-ik/releases/download/2.0.1/opensearch-analisys-ik-2.0.1.zip` |
 
 
 #### Quick Example

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        opensearch_version = "2.0.0"
+        opensearch_version = "2.0.1"
     }
 
     repositories {


### PR DESCRIPTION
note: if #3 (fixing the name of the plugin) gets merged before this
release is done then the URL for 2.0.1 in the README will also have to
be fixed accordingly - i've now created this PR still with the typo in
it so that 2.0.1 can be released as soon as possible (we rely on it)).

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>