### PR TITLE
fix for opensearch release 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        opensearch_version = "2.0.1"
+        opensearch_version = "2.1.0"
     }
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-opensearchVersion = 2.1.0
+opensearchVersion = 2.1.0.0


### PR DESCRIPTION
currently the release 2.1.0 is broken, because a version was not updated in the build.gradle

i fixed this and also changed the version in the gradle.properties to the correct release versions, how plugins should be versioned

i am not able to build and test this, so feedback is welcome