### PR TITLE
explicitly flag javadoc as UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,3 +139,6 @@ task updateVersion {
     }
 }
 
+javadoc {
+    options.encoding = 'UTF-8'
+}


### PR DESCRIPTION
without this the build on windows fails with the following type of error:
```
[...]\opensearch-analysis-ik\src\main\java\org\wltea\analyzer\cfg\Configuration.java:18: error: unmappable character (0x90) for encoding windows-1252
```