### PR TITLE
fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @AmiStrn @dblock @saratvemulapalli @reta
+*   @aparo


### PR DESCRIPTION
this was copied 1:1 from the template in commit aa1aaaa, however it must only contain people granted write access on the repo. at the moment this seems to be only @aparo.

as that commit had been pushed directly GH didn't stop it; if it were added as a PR then GH would've run a validation which would've blocked the PR. nevertheless GH still shows an error on the commit which added it (which is how i spotted the problem).