### PR TITLE
fix org/apache/commons/logging/LogFactory NoClassDefFoundError problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ repositories {
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
     implementation group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.16'
+    implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
 }
 
 test {


### PR DESCRIPTION
There is a NoClassDefFound Error while using dictionary hot update function. To fix this problem, added commons-logging dependency
![image](https://github.com/aparo/opensearch-analysis-ik/assets/14546028/ebf51df7-fdf5-4d07-a5cd-e5ef2a801dd4)
